### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -10,7 +10,16 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
-            using (FileStream fs = File.Open(userInput, FileMode.Open))
+            string baseDirectory = Path.GetFullPath("SafeDirectory"); // Define a safe base directory
+            string filePath = Path.GetFullPath(Path.Combine(baseDirectory, userInput)); // Combine and normalize the path
+
+            // Ensure the resolved path is within the base directory
+            if (!filePath.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+            {
+                throw new UnauthorizedAccessException("Invalid file path.");
+            }
+
+            using (FileStream fs = File.Open(filePath, FileMode.Open))
             {
                 byte[] b = new byte[1024];
                 UTF8Encoding temp = new UTF8Encoding(true);


### PR DESCRIPTION
Potential fix for [https://github.com/geovanams/DemoGHASBOX/security/code-scanning/1](https://github.com/geovanams/DemoGHASBOX/security/code-scanning/1)

To fix the issue, we need to validate the `userInput` parameter to ensure it does not contain any malicious path components (e.g., `..`, `/`, or `\`) that could lead to path traversal attacks. Additionally, we should restrict file access to a specific directory to ensure that even valid file names cannot access files outside the intended directory.

The fix involves:
1. Defining a safe base directory where files are allowed to be accessed.
2. Normalizing the user-provided path and ensuring it resolves within the safe base directory.
3. Rejecting any input that does not meet these criteria.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
